### PR TITLE
fix fatal error

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ class Vuetify {
 
         const deps = ['vuetify', 'sass', 'sass-loader', 'fibers', 'deepmerge']
 
-        if (this.withVueLoader()) deps.push('vuetify-loader')
+        if (this.withVuetifyLoader()) deps.push('vuetify-loader')
 
         return deps
     }


### PR DESCRIPTION
When running the latest version, I got a fatal error "this.withVueLoader is not a function". It's because the function was renamed in the prior commit, but not changed in all places.